### PR TITLE
String tests

### DIFF
--- a/src/pidgin/docs/markdown strings.md.ipynb
+++ b/src/pidgin/docs/markdown strings.md.ipynb
@@ -1,0 +1,697 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook illustrates how __Markdown__ strings may blend with __Python__ using `pidgin`.\n",
+    "\n",
+    "    import pidgin"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "    from IPython import get_ipython\n",
+    "    %reload_ext pidgin"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<p><code>pidgin</code> emphasizes that everything is code.  Blocks of <em>non-code</em> <strong>Markdown</strong> are transformed \n",
+       "represented as block strings in <code>pidgin</code>, they are not converted to comments.  Converting <strong>Markdown</strong>\n",
+       "to strings permits interesting hybrids of <strong>Markdown</strong> and <strong>Python</strong>.</p>\n",
+       "<pre><code>import pidgin\n",
+       "</code></pre>"
+      ],
+      "text/markdown": [
+       "`pidgin` emphasizes that everything is code.  Blocks of _non-code_ __Markdown__ are transformed \n",
+       "represented as block strings in `pidgin`, they are not converted to comments.  Converting __Markdown__\n",
+       "to strings permits interesting hybrids of __Markdown__ and __Python__.\n",
+       "\n",
+       "    import pidgin"
+      ],
+      "text/plain": [
+       "'`pidgin` emphasizes that everything is code.  Blocks of _non-code_ __Markdown__ are transformed \\nrepresented as block strings in `pidgin`, they are not converted to comments.  Converting __Markdown__\\nto strings permits interesting hybrids of __Markdown__ and __Python__.\\n\\n    import pidgin'"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "`pidgin` emphasizes that everything is code.  Blocks of _non-code_ __Markdown__ are transformed \n",
+    "represented as block strings in `pidgin`, they are not converted to comments.  Converting __Markdown__\n",
+    "to strings permits interesting hybrids of __Markdown__ and __Python__.\n",
+    "\n",
+    "    import pidgin"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<h1>Assigning <strong>Markdown</strong> string objects.</h1>\n",
+       "<pre><code>foo =\\\n",
+       "</code></pre>\n",
+       "<p>A line continuation can be used to define a variable \n",
+       "with the <strong>Markdown</strong> content following it</p>\n",
+       "<p>Carriage returns are allowed.</p>\n",
+       "<pre><code>bar = \"code breaks the string and the next line is evaluated.\"\n",
+       "\n",
+       "def test_bar(): assert 'bar' in globals()\n",
+       "</code></pre>"
+      ],
+      "text/markdown": [
+       "# Assigning __Markdown__ string objects.\n",
+       "\n",
+       "    foo =\\\n",
+       "A line continuation can be used to define a variable \n",
+       "with the __Markdown__ content following it\n",
+       "\n",
+       "Carriage returns are allowed.\n",
+       "\n",
+       "    bar = \"code breaks the string and the next line is evaluated.\"\n",
+       "    \n",
+       "    def test_bar(): assert 'bar' in globals()"
+      ],
+      "text/plain": [
+       "'# Assigning __Markdown__ string objects.\\n\\n    foo =\\\\\\nA line continuation can be used to define a variable \\nwith the __Markdown__ content following it\\n\\nCarriage returns are allowed.\\n\\n    bar = \"code breaks the string and the next line is evaluated.\"\\n    \\n    def test_bar(): assert \\'bar\\' in globals()'"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Assigning __Markdown__ string objects.\n",
+    "\n",
+    "    foo =\\\n",
+    "A line continuation can be used to define a variable \n",
+    "with the __Markdown__ content following it\n",
+    "\n",
+    "Carriage returns are allowed.\n",
+    "\n",
+    "    bar = \"code breaks the string and the next line is evaluated.\"\n",
+    "    \n",
+    "    def test_bar(): assert 'bar' in globals()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "    import inspect"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<h1>Assigning <strong>Markdown</strong> string objects.</h1>\n",
+       "<pre><code>foo_paren = (\n",
+       "</code></pre>\n",
+       "<p>A string may be defined in parenthesis.</p>\n",
+       "<p>The line below is markdown because it is not indented.</p>\n",
+       "<p>)</p>\n",
+       "<pre><code>)\n",
+       "\n",
+       "\n",
+       "def test_paren(): assert foo_paren.endswith(')')\n",
+       "\n",
+       "def test_function_with_docstring(): (\n",
+       "</code></pre>\n",
+       "<p>This is a docstring for <code>test_function_with_docstring</code>.  Nothing may be defined inside the function\n",
+       "because the parenthesis bound the expression.</p>\n",
+       "<pre><code>)\n",
+       "assert True\n",
+       "\n",
+       "def test_function_with_docstring_for_real():\n",
+       "    assert 'assert' not in inspect.getsource(test_function_with_docstring)\n",
+       "</code></pre>"
+      ],
+      "text/markdown": [
+       "# Assigning __Markdown__ string objects.\n",
+       "\n",
+       "    foo_paren = (\n",
+       "A string may be defined in parenthesis.\n",
+       "\n",
+       "The line below is markdown because it is not indented.\n",
+       "        \n",
+       ") \n",
+       "    \n",
+       "    )\n",
+       "    \n",
+       "    \n",
+       "    def test_paren(): assert foo_paren.endswith(')')\n",
+       "        \n",
+       "    def test_function_with_docstring(): (\n",
+       "This is a docstring for `test_function_with_docstring`.  Nothing may be defined inside the function\n",
+       "because the parenthesis bound the expression.\n",
+       "    \n",
+       "    )\n",
+       "    assert True\n",
+       "    \n",
+       "    def test_function_with_docstring_for_real():\n",
+       "        assert 'assert' not in inspect.getsource(test_function_with_docstring)"
+      ],
+      "text/plain": [
+       "\"# Assigning __Markdown__ string objects.\\n\\n    foo_paren = (\\nA string may be defined in parenthesis.\\n\\nThe line below is markdown because it is not indented.\\n        \\n) \\n    \\n    )\\n    \\n    \\n    def test_paren(): assert foo_paren.endswith(')')\\n        \\n    def test_function_with_docstring(): (\\nThis is a docstring for `test_function_with_docstring`.  Nothing may be defined inside the function\\nbecause the parenthesis bound the expression.\\n    \\n    )\\n    assert True\\n    \\n    def test_function_with_docstring_for_real():\\n        assert 'assert' not in inspect.getsource(test_function_with_docstring)\""
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Assigning __Markdown__ string objects.\n",
+    "\n",
+    "    foo_paren = (\n",
+    "A string may be defined in parenthesis.\n",
+    "\n",
+    "The line below is markdown because it is not indented.\n",
+    "        \n",
+    ") \n",
+    "    \n",
+    "    )\n",
+    "    \n",
+    "    \n",
+    "    def test_paren(): assert foo_paren.endswith(')')\n",
+    "        \n",
+    "    def test_function_with_docstring(): (\n",
+    "This is a docstring for `test_function_with_docstring`.  Nothing may be defined inside the function\n",
+    "because the parenthesis bound the expression.\n",
+    "    \n",
+    "    )\n",
+    "    assert True\n",
+    "    \n",
+    "    def test_function_with_docstring_for_real():\n",
+    "        assert 'assert' not in inspect.getsource(test_function_with_docstring)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "THIS STRING IS INSIDE PARENTHESIS.  IT WILL BE `PRINT`ED UPPER CASE.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<h1>Applying string methods</h1>\n",
+       "<p>Markdown inside parenthesis may have string methods applied.</p>\n",
+       "<pre><code>value = 42\n",
+       "print(\n",
+       "</code></pre>\n",
+       "<p>This string is inside parenthesis.  It will be <code>print</code>ed upper case.</p>\n",
+       "<pre><code>.upper())\n",
+       "\n",
+       "formatted_upper = (\n",
+       "</code></pre>\n",
+       "<p>Format may be used to insert values {}</p>\n",
+       "<pre><code>.format(value).upper())\n",
+       "\n",
+       "assert formatted_upper.endswith('42')\n",
+       "</code></pre>"
+      ],
+      "text/markdown": [
+       "# Applying string methods\n",
+       "\n",
+       "Markdown inside parenthesis may have string methods applied.\n",
+       "\n",
+       "    value = 42\n",
+       "    print(\n",
+       "This string is inside parenthesis.  It will be `print`ed upper case.\n",
+       "    \n",
+       "    .upper())\n",
+       "    \n",
+       "    formatted_upper = (\n",
+       "Format may be used to insert values {}\n",
+       "        \n",
+       "    .format(value).upper())\n",
+       "    \n",
+       "    assert formatted_upper.endswith('42')\n",
+       "    "
+      ],
+      "text/plain": [
+       "\"# Applying string methods\\n\\nMarkdown inside parenthesis may have string methods applied.\\n\\n    value = 42\\n    print(\\nThis string is inside parenthesis.  It will be `print`ed upper case.\\n    \\n    .upper())\\n    \\n    formatted_upper = (\\nFormat may be used to insert values {}\\n        \\n    .format(value).upper())\\n    \\n    assert formatted_upper.endswith('42')\\n    \""
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Applying string methods\n",
+    "\n",
+    "Markdown inside parenthesis may have string methods applied.\n",
+    "\n",
+    "    value = 42\n",
+    "    print(\n",
+    "This string is inside parenthesis.  It will be `print`ed upper case.\n",
+    "    \n",
+    "    .upper())\n",
+    "    \n",
+    "    formatted_upper = (\n",
+    "Format may be used to insert values {}\n",
+    "        \n",
+    "    .format(value).upper())\n",
+    "    \n",
+    "    assert formatted_upper.endswith('42')\n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<h1>f strings</h1>\n",
+       "<pre><code>value = 42\n",
+       "ffoo = F\"\"\"\n",
+       "</code></pre>\n",
+       "<p>Insert the a value in the <code>ffoo</code> as {value}</p>\n",
+       "<pre><code>\"\"\"\n",
+       "ffoo.rstrip().endswith(str(value))\n",
+       "</code></pre>"
+      ],
+      "text/markdown": [
+       "# f strings\n",
+       "\n",
+       "    value = 42\n",
+       "    ffoo = F\"\"\"\n",
+       "Insert the a value in the `ffoo` as {value}\n",
+       "\n",
+       "    \"\"\"\n",
+       "    ffoo.rstrip().endswith(str(value))"
+      ],
+      "text/plain": [
+       "'# f strings\\n\\n    value = 42\\n    ffoo = F\"\"\"\\nInsert the a value in the `ffoo` as {value}\\n\\n    \"\"\"\\n    ffoo.rstrip().endswith(str(value))'"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# f strings\n",
+    "\n",
+    "    value = 42\n",
+    "    ffoo = F\"\"\"\n",
+    "Insert the a value in the `ffoo` as {value}\n",
+    "\n",
+    "    \"\"\"\n",
+    "    ffoo.rstrip().endswith(str(value))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<h2>Literate blocks</h2>\n",
+       "<p><code>pidgin</code> permits an author to explicitly wrapped their Markdown in quotes.</p>\n",
+       "<pre><code>wrapped_foo_lines = \"\"\"\n",
+       "</code></pre>\n",
+       "<p>I am the string.</p>\n",
+       "<pre><code>\"\"\".splitlines()\n",
+       "assert not wrapped_foo_lines[0].strip()\n",
+       "assert any(map(str.strip, wrapped_foo_lines))\n",
+       "</code></pre>\n",
+       "<p>To include a first line in a literal block the author will have to concat the lines like below.</p>\n",
+       "<pre><code>wrapped_foo_first_line = \"The first line\" \"\"\"\n",
+       "</code></pre>\n",
+       "<p>I'm in the block</p>\n",
+       "<pre><code>\"\"\"\n",
+       "assert wrapped_foo_first_line.startswith('The')\n",
+       "assert wrapped_foo_first_line.splitlines()[1].strip()\n",
+       "</code></pre>"
+      ],
+      "text/markdown": [
+       "## Literate blocks\n",
+       "\n",
+       "`pidgin` permits an author to explicitly wrapped their Markdown in quotes.\n",
+       "\n",
+       "    wrapped_foo_lines = \"\"\"\n",
+       "I am the string.\n",
+       "    \n",
+       "    \"\"\".splitlines()\n",
+       "    assert not wrapped_foo_lines[0].strip()\n",
+       "    assert any(map(str.strip, wrapped_foo_lines))\n",
+       "    \n",
+       "To include a first line in a literal block the author will have to concat the lines like below.\n",
+       "    \n",
+       "    wrapped_foo_first_line = \"The first line\" \"\"\"\n",
+       "I'm in the block\n",
+       "\n",
+       "    \"\"\"\n",
+       "    assert wrapped_foo_first_line.startswith('The')\n",
+       "    assert wrapped_foo_first_line.splitlines()[1].strip()"
+      ],
+      "text/plain": [
+       "'## Literate blocks\\n\\n`pidgin` permits an author to explicitly wrapped their Markdown in quotes.\\n\\n    wrapped_foo_lines = \"\"\"\\nI am the string.\\n    \\n    \"\"\".splitlines()\\n    assert not wrapped_foo_lines[0].strip()\\n    assert any(map(str.strip, wrapped_foo_lines))\\n    \\nTo include a first line in a literal block the author will have to concat the lines like below.\\n    \\n    wrapped_foo_first_line = \"The first line\" \"\"\"\\nI\\'m in the block\\n\\n    \"\"\"\\n    assert wrapped_foo_first_line.startswith(\\'The\\')\\n    assert wrapped_foo_first_line.splitlines()[1].strip()'"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "## Literate blocks\n",
+    "\n",
+    "`pidgin` permits an author to explicitly wrapped their Markdown in quotes.\n",
+    "\n",
+    "    wrapped_foo_lines = \"\"\"\n",
+    "I am the string.\n",
+    "    \n",
+    "    \"\"\".splitlines()\n",
+    "    assert not wrapped_foo_lines[0].strip()\n",
+    "    assert any(map(str.strip, wrapped_foo_lines))\n",
+    "    \n",
+    "To include a first line in a literal block the author will have to concat the lines like below.\n",
+    "    \n",
+    "    wrapped_foo_first_line = \"The first line\" \"\"\"\n",
+    "I'm in the block\n",
+    "\n",
+    "    \"\"\"\n",
+    "    assert wrapped_foo_first_line.startswith('The')\n",
+    "    assert wrapped_foo_first_line.splitlines()[1].strip()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<p>Combining literate and normal blocks</p>\n",
+       "<pre><code>combo_string = \"\"\"\n",
+       "</code></pre>\n",
+       "<p>String with a literal string</p>\n",
+       "<pre><code>\"\"\" \\\n",
+       "</code></pre>\n",
+       "<p>And concat an normal markdown block</p>\n",
+       "<pre><code>combo_string.endswith('block')\n",
+       "</code></pre>"
+      ],
+      "text/markdown": [
+       "Combining literate and normal blocks\n",
+       "\n",
+       "    combo_string = \"\"\"\n",
+       "String with a literal string\n",
+       "\n",
+       "    \"\"\" \\\n",
+       "And concat an normal markdown block\n",
+       "    \n",
+       "    combo_string.endswith('block')"
+      ],
+      "text/plain": [
+       "'Combining literate and normal blocks\\n\\n    combo_string = \"\"\"\\nString with a literal string\\n\\n    \"\"\" \\\\\\nAnd concat an normal markdown block\\n    \\n    combo_string.endswith(\\'block\\')'"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "Combining literate and normal blocks\n",
+    "\n",
+    "    combo_string = \"\"\"\n",
+    "String with a literal string\n",
+    "\n",
+    "    \"\"\" \\\n",
+    "And concat an normal markdown block\n",
+    "    \n",
+    "    combo_string.endswith('block')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<p>Following a markdown block with a literal block must happen in parenthesis.</p>\n",
+       "<pre><code>combo_md_first = (\n",
+       "</code></pre>\n",
+       "<p>Markdown starts the string</p>\n",
+       "<pre><code>    \"\"\"\n",
+       "</code></pre>\n",
+       "<p>This literal is injected into the string</p>\n",
+       "<pre><code>    \"\"\" \\\n",
+       "</code></pre>\n",
+       "<p>A normal markdown string follows a line continuation otherwise \n",
+       "it is not wrapped in quotes.</p>\n",
+       "<pre><code>)\n",
+       "</code></pre>"
+      ],
+      "text/markdown": [
+       "Following a markdown block with a literal block must happen in parenthesis.\n",
+       "\n",
+       "    combo_md_first = (\n",
+       "Markdown starts the string\n",
+       "        \n",
+       "        \"\"\"\n",
+       "This literal is injected into the string\n",
+       "        \n",
+       "        \"\"\" \\\n",
+       "A normal markdown string follows a line continuation otherwise \n",
+       "it is not wrapped in quotes.\n",
+       "    \n",
+       "    )"
+      ],
+      "text/plain": [
+       "'Following a markdown block with a literal block must happen in parenthesis.\\n\\n    combo_md_first = (\\nMarkdown starts the string\\n        \\n        \"\"\"\\nThis literal is injected into the string\\n        \\n        \"\"\" \\\\\\nA normal markdown string follows a line continuation otherwise \\nit is not wrapped in quotes.\\n    \\n    )'"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "Following a markdown block with a literal block must happen in parenthesis.\n",
+    "\n",
+    "    combo_md_first = (\n",
+    "Markdown starts the string\n",
+    "        \n",
+    "        \"\"\"\n",
+    "This literal is injected into the string\n",
+    "        \n",
+    "        \"\"\" \\\n",
+    "A normal markdown string follows a line continuation otherwise \n",
+    "it is not wrapped in quotes.\n",
+    "    \n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "    import unittest"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<p><strong>Markdown</strong> can be used to annotate classses.</p>\n",
+       "<pre><code>class MarkdownDocstrings(unittest.TestCase):\n",
+       "</code></pre>\n",
+       "<p>I am the markdown docstring.</p>\n",
+       "<pre><code>    def test_markdown_string(self):\n",
+       "</code></pre>\n",
+       "<p><code>MarkdownDocstrings.test_markdown_string</code> tests that the class and function docstrings were set.</p>\n",
+       "<pre><code>        assert self.__doc__.startswith('I am the')\n",
+       "        assert self.test_markdown_string.__doc__.startswith(\n",
+       "</code></pre>\n",
+       "<p><code>MarkdownDocstrings.test_markdown_string</code></p>\n",
+       "<pre><code>        )\n",
+       "</code></pre>"
+      ],
+      "text/markdown": [
+       "__Markdown__ can be used to annotate classses.\n",
+       "\n",
+       "    class MarkdownDocstrings(unittest.TestCase):\n",
+       "I am the markdown docstring.\n",
+       "        \n",
+       "        def test_markdown_string(self):\n",
+       "`MarkdownDocstrings.test_markdown_string` tests that the class and function docstrings were set.\n",
+       "\n",
+       "            assert self.__doc__.startswith('I am the')\n",
+       "            assert self.test_markdown_string.__doc__.startswith(\n",
+       "`MarkdownDocstrings.test_markdown_string`\n",
+       "            \n",
+       "            )"
+      ],
+      "text/plain": [
+       "\"__Markdown__ can be used to annotate classses.\\n\\n    class MarkdownDocstrings(unittest.TestCase):\\nI am the markdown docstring.\\n        \\n        def test_markdown_string(self):\\n`MarkdownDocstrings.test_markdown_string` tests that the class and function docstrings were set.\\n\\n            assert self.__doc__.startswith('I am the')\\n            assert self.test_markdown_string.__doc__.startswith(\\n`MarkdownDocstrings.test_markdown_string`\\n            \\n            )\""
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "__Markdown__ can be used to annotate classses.\n",
+    "\n",
+    "    class MarkdownDocstrings(unittest.TestCase):\n",
+    "I am the markdown docstring.\n",
+    "        \n",
+    "        def test_markdown_string(self):\n",
+    "`MarkdownDocstrings.test_markdown_string` tests that the class and function docstrings were set.\n",
+    "\n",
+    "            assert self.__doc__.startswith('I am the')\n",
+    "            assert self.test_markdown_string.__doc__.startswith(\n",
+    "`MarkdownDocstrings.test_markdown_string`\n",
+    "            \n",
+    "            )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "run me\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre><code>endswith_block_quote = \\\n",
+       "</code></pre>\n",
+       "<p>We should be able to use blocks quotes</p>\n",
+       "<blockquote><p>Ya heard?</p>\n",
+       "</blockquote>\n",
+       "<pre><code>...\n",
+       "\n",
+       "assert print(\n",
+       "</code></pre>\n",
+       "<p>run me</p>\n",
+       "<pre><code>) or endswith_block_quote.splitlines()[-1].startswith('&gt; ')\n",
+       "</code></pre>"
+      ],
+      "text/markdown": [
+       "    endswith_block_quote = \\\n",
+       "We should be able to use blocks quotes\n",
+       "    \n",
+       "> Ya heard?\n",
+       "        \n",
+       "    ...\n",
+       "\n",
+       "    assert print(\n",
+       "run me\n",
+       "        \n",
+       "    ) or endswith_block_quote.splitlines()[-1].startswith('> ')"
+      ],
+      "text/plain": [
+       "\"    endswith_block_quote = \\\\\\nWe should be able to use blocks quotes\\n    \\n> Ya heard?\\n        \\n    ...\\n\\n    assert print(\\nrun me\\n        \\n    ) or endswith_block_quote.splitlines()[-1].startswith('> ')\""
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "    endswith_block_quote = \\\n",
+    "We should be able to use blocks quotes\n",
+    "    \n",
+    "> Ya heard?\n",
+    "        \n",
+    "    ...\n",
+    "\n",
+    "    assert print(\n",
+    "run me\n",
+    "        \n",
+    "    ) or endswith_block_quote.splitlines()[-1].startswith('> ')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/src/pidgin/tangle.ipynb
+++ b/src/pidgin/tangle.ipynb
@@ -16,7 +16,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -33,7 +33,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -60,7 +60,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -79,7 +79,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -95,7 +95,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -118,17 +118,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
-    "    class BlockLexer(mistune.BlockLexer): list_rules = default_rules = ['newline', 'fences', 'block_code', 'list_block', 'paragraph', 'text']\n",
-    "    class InlineLexer(mistune.InlineLexer):  inline_html_rules = default_rules = ['text']"
+    "    class BlockLexer(mistune.BlockLexer): \n",
+    "        list_rules = default_rules = [\n",
+    "            'newline', 'fences', 'block_code', 'block_quote', 'list_block', 'paragraph', 'text']\n",
+    "    class InlineLexer(mistune.InlineLexer):  \n",
+    "        inline_html_rules = default_rules = ['text']"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -213,7 +216,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -234,7 +237,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -254,7 +257,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -266,7 +269,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -276,7 +279,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -287,7 +290,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [


### PR DESCRIPTION
Add tests for different markdown and python string combinations.  

Fix a tiny inconsistency when converting block quotes.