### PR TITLE
add an extras extension for convenient interactive dev features.

### DIFF
--- a/src/pidgy/__init__.py
+++ b/src/pidgy/__init__.py
@@ -6,15 +6,16 @@ LOADED = False
 
 
 def load_ipython_extension(shell):
-    from . import tangle, weave
+    from . import tangle, weave, extras
 
-    shell.user_ns.setdefault("shell", shell)
+    extras.load_ipython_extension(shell)
     tangle.load_ipython_extension(shell)
     weave.load_ipython_extension(shell)
 
 
 def unload_ipython_extension(shell):
-    from . import tangle, weave
+    from . import tangle, weave, extras
 
+    extras.unload_ipython_extension(shell)
     tangle.unload_ipython_extension(shell)
     weave.unload_ipython_extension(shell)

--- a/src/pidgy/extras.py
+++ b/src/pidgy/extras.py
@@ -1,0 +1,31 @@
+"""the extras extension adds features that improve interactive computing
+
+1. exposes the `shell` variable for quick access to the interactive instance.
+2. each execution the sys modules are populated in the namespace.
+  
+  this feature minimizes time between computing iterations by bringing more completion sooner.
+  in an interactive computing session, the sys modules hold variable names not available to
+  the author, but when available help continue flow between executions.
+"""
+
+from sys import modules
+import IPython
+
+
+def update_sys_modules():
+    """update the shell's user namespace to include imported modules"""
+    shell = IPython.get_ipython()
+    shell.user_ns.update(
+        (k, v)
+        for k, v in modules.items()
+        if k and k[0] != "_" and "." not in k and k not in shell.user_ns
+    )
+
+
+def load_ipython_extension(shell: IPython.InteractiveShell):
+    shell.user_ns.setdefault("shell", shell)
+    shell.events.register("pre_execute", update_sys_modules)
+
+
+def unload_ipython_extension(shell: IPython.InteractiveShell):
+    shell.events.unregister("pre_execute", update_sys_modules)


### PR DESCRIPTION
when interactive computing in python there are namespaces loaded that arent easy to access. to access loaded modules they need to be explicitly imported. in an effort to continue with a flow state we elevated any modules in the `sys.modules` to the global namespace for quick access. this offers more implicit variables in the namespace based on what loaded in the `sys.modules`.